### PR TITLE
Fix errors during container build that happen during file extraction

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@ if [ ! -z ${_BUILD_ARG_GOOGLE_CLOUD_SDK} ]; then
     curl -o google-cloud-sdk.tar.gz "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${file}.tar.gz"
 
     echo "Extracting ${file}..."
-    tar -xvzf ./google-cloud-sdk.tar.gz
+    tar -xvf ./google-cloud-sdk.tar.gz
 
     echo "Installing ${file}..."
     mv ./google-cloud-sdk /usr/local/share/google-cloud-sdk


### PR DESCRIPTION
We get lots of errors trying to install gcloud-sdk when rebuilding containers that look like:
```
[2022-06-24T15:06:32.391Z] Extracting google-cloud-sdk-369.0.0-Linux-aarch64...
[2022-06-24T15:06:32.395Z] 
gzip: stdin: not in gzip format
tar: Error is not recoverable: exiting now
```

You'd think we'd need the -z given the url looks to be gzipped but the docs don't use it https://cloud.google.com/sdk/docs/install#linux:
```
tar -xf google-cloud-cli-391.0.0-linux-x86.tar.gz
```